### PR TITLE
bugfix: add missing use stmt

### DIFF
--- a/src/FlexUserProviderFactory.php
+++ b/src/FlexUserProviderFactory.php
@@ -3,6 +3,7 @@
 namespace FlexAuthBundle;
 
 use FlexAuthBundle\DependencyInjection\FlexAuthExtension;
+use FlexAuth\FlexAuthTypeProviderFactory;
 use FlexAuth\FlexAuthTypeProviderInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;


### PR DESCRIPTION
Just a quick bugfix to add a missing use statement and avoid a class not found exception.